### PR TITLE
add tag decoding

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+IndentWidth: 4
+AccessModifierOffset: -4
+IndentPPDirectives: BeforeHash

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,10 @@
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update
+          compliance: strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,92 @@
-.DS_Store
+# arduino IDE build
+build
+
+# Notepad++ backups
+*.bak
+**/nppBackup
+
+# manual backups
+**/old
+*.zip
+
+## C & CPP things
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# editors
+# =========================
 .vscode
 .development
-src.ino
+
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+linelength=90

--- a/examples/Simple2Read/README.md
+++ b/examples/Simple2Read/README.md
@@ -1,0 +1,26 @@
+# Simple2Read
+
+This example demonstrates how you can use `SimpleRFID2` to read the ID from a near RFID tag.
+
+## Materials
+
+To run this example you need these components:
+
+-   [Arduino](https://store.arduino.cc/arduino-genuino/boards-modules)
+-   [Groove RFID Reader](http://wiki.seeedstudio.com/Grove-125KHz_RFID_Reader/)
+-   At least one RFID tag (chip or card)
+-   Grove-Kabel
+-   [Grove Shield](http://wiki.seeedstudio.com/Base_Shield_V2/)
+
+## Setup
+
+1. Open the example skecth by selecting `File > Examples > SimpleRFID > Simple2Read`
+2. Connect the RFID-reader to your Arduino (RX to PIN2, TX to PIN3 → Port Groove D2)
+3. Connect your Ardunio to your PC
+4. Upload the code to your Arduino
+5. Open the serial monitor by selecting `Tools > Serial Monitor`
+
+## Usage
+
+Hold a RFID tag close to the RFID reader and look at the monitor.
+The monitor should print the ID of the tag.

--- a/examples/Simple2Read/Simple2Read.ino
+++ b/examples/Simple2Read/Simple2Read.ino
@@ -1,0 +1,37 @@
+/*
+    Prints out the ID of any chip you scan.
+
+    based on 4 Apr 2019 by
+    Luai Malek and
+    Roman Schulte
+    modified for SimpleRFID2 by Stefan Krüger
+*/
+
+#include "SimpleRFID2.h"
+
+uint32_t id = "";
+
+// Setup RFID reader on pin 2 and 3 (D2 on base shield).
+const uint8_t rfid_rx_pin = 2;
+const uint8_t rfid_tx_pin = 3;
+SimpleRFID2 simple_rfid(rfid_rx_pin, rfid_tx_pin);
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("Simple2Read.ino");
+}
+
+void loop() {
+    // check if data is ready to be read
+    if (simple_rfid.available()) {
+        // read the id
+        id = simple_rfid.readDecodedID();
+        // check again vor valid id / tag
+        if (id > 0) {
+            Serial.print("Found Tag: ");
+            Serial.print(id);
+            Serial.println();
+        }
+    }
+    // Here you can add additional behaviour if wanted.
+}

--- a/examples/Simple2ReadLookup/README.md
+++ b/examples/Simple2ReadLookup/README.md
@@ -1,0 +1,31 @@
+# Simple2ReadLookup
+
+This example demonstrates how you can use `SimpleRFID2` to read the ID from a near RFID tag 
+and print additional (hard-coded) information from a *lookup*
+
+## Materials
+
+To run this example you need these components:
+
+-   [Arduino](https://store.arduino.cc/arduino-genuino/boards-modules)
+-   [Groove RFID Reader](http://wiki.seeedstudio.com/Grove-125KHz_RFID_Reader/)
+-   At least one RFID tag (chip or card)
+-   Grove-Kabel
+-   [Grove Shield](http://wiki.seeedstudio.com/Base_Shield_V2/)
+
+## Setup
+
+1. Open the example skecth by selecting `File > Examples > SimpleRFID > Simple2Read`
+2. Connect the RFID-reader to your Arduino (RX to PIN2, TX to PIN3 → Port Groove D2)
+3. Connect your Ardunio to your PC
+4. Upload the code to your Arduino
+5. Open the serial monitor by selecting `Tools > Serial Monitor`
+
+## Usage
+
+Hold a RFID tag close to the RFID reader and look at the monitor.
+The monitor should print the ID of the tag.
+if the tag is *known* the `Name` and `Age` of the person is printed.
+you have to edit the `person_list` so that your tag-ids are *known*.
+the IDs should be printed on the physical tags. 
+They are maximal 10 characters long - leading zeros are ignored.

--- a/examples/Simple2ReadLookup/Simple2ReadLookup.ino
+++ b/examples/Simple2ReadLookup/Simple2ReadLookup.ino
@@ -1,0 +1,70 @@
+/*
+    read tag and check if it is a known *Person*.
+*/
+
+#include "SimpleRFID2.h"
+
+// Setup RFID reader on pin 2 and 3 (D2 on base shield).
+const uint8_t rfid_rx_pin = 2;
+const uint8_t rfid_tx_pin = 3;
+SimpleRFID2 simple_rfid(rfid_rx_pin, rfid_tx_pin);
+
+struct person_t {
+    uint32_t tag;
+    String name;
+    uint8_t age;
+};
+
+const person_t person_list[] = {
+    {7569585, "Bob", 17},
+    {7562924, "Martin", 35},
+    {334155100, "Sabine", 17},
+    {334016718, "Melanie", 13}, 
+    {7768928, "Rudolf", 9},
+    {13007523, "Monster", 10},
+    {6654217, "Juliane", 22},
+    // {355189219, "Laura", 11},
+};
+// get size of memory for person, divide by size of type to get count...
+const uint8_t person_list_COUNT = sizeof(person_list) / sizeof(person_t);
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("Simple2ReadLookup.ino");
+}
+
+void loop() {
+    if (simple_rfid.available()) {
+        uint32_t id = simple_rfid.readDecodedID();
+        if (id > 0) {
+            tag_found(id);
+        }
+    }
+}
+
+void tag_found(uint32_t tag) {
+    int8_t person_index = find_person_index(tag);
+    if (person_index != -1) {
+        Serial.print("Found Person: ");
+        Serial.print(person_list[person_index].name);
+        Serial.print(" (");
+        Serial.print(person_list[person_index].age);
+        Serial.print(")");
+        Serial.println();
+    } else {
+        Serial.print("Tag Unknown: ");
+        Serial.print(tag);
+        Serial.println();
+    }
+}
+
+int8_t find_person_index(int32_t tag) {
+    // we return -1 if we do not find a match...
+    int8_t person_index = -1;
+    for (size_t i = 0; i < person_list_COUNT; i++) {
+        if (person_list[i].tag == tag) {
+            person_index = i;
+        }
+    }
+    return person_index;
+}

--- a/examples/SimpleAuthentification/SimpleAuthentification.ino
+++ b/examples/SimpleAuthentification/SimpleAuthentification.ino
@@ -1,16 +1,16 @@
 /*
-  Distinguish between authorized and unauthorized tags and play 
-  different beep-tones accordingly.
+    Distinguish between authorized and unauthorized tags and play
+    different beep-tones accordingly.
 
-  Created on 4 Apr 2019 by
-  Luai Malek and
-  Roman Schulte
+    Created on 4 Apr 2019 by
+    Luai Malek and
+    Roman Schulte
 */
-
 
 #include "SimpleRFID.h"
 
-String authorized_tags = "";  //this string will hold all registered IDs, seperated by whitespaces
+// this string will hold all registered IDs, seperated by whitespaces
+String authorized_tags = "";
 
 // Initialize reader with pins 2 and 3 (D2 on base shield).
 const uint8_t rfid_rx_pin = 2;
@@ -21,68 +21,55 @@ SimpleRFID simple_rfid(rfid_rx_pin, rfid_tx_pin);
 const uint8_t buzzer_pin = 5;
 
 // Connect button with pin 7 (D7 on base shield).
-const uint8_t button_pin = 7; 
+const uint8_t button_pin = 7;
 
-void setup() 
-{
-  // Setup pin modes
-  pinMode(buzzer_pin, OUTPUT);
-  pinMode(button_pin, INPUT);
+void setup() {
+    // Setup pin modes
+    pinMode(buzzer_pin, OUTPUT);
+    pinMode(button_pin, INPUT);
 }
 
-void loop() 
-{
-  // Is RFID tag in front of reader?
-  if (simple_rfid.available()) 
-  {
-    String new_ID = simple_rfid.readID();
+void loop() {
+    // Is RFID tag in front of reader?
+    if (simple_rfid.available()) {
+        String new_ID = simple_rfid.readID();
 
-    // Is button pressed?
-    if (digitalRead(button_pin) == HIGH)
-    {
-      // Check if RFID tag is already authorized
-      int index = authorized_tags.indexOf(new_ID);
-      if (index > 0) 
-      {
-        // Remove tag from authorized list
-        authorized_tags = authorized_tags.substring(0, index - 1) \
-        + authorized_tags.substring(index + new_ID.length());
-        beep(200, 2);
-      }
-      else
-      {
-        // Add tag to authorized list
-        authorized_tags = authorized_tags + " " + new_ID;
-        beep(200, 1);
-      }   
-    }
-    else 
-    {
-      int index = authorized_tags.indexOf(new_ID);
+        // Is button pressed?
+        if (digitalRead(button_pin) == HIGH) {
+            // Check if RFID tag is already authorized
+            int index = authorized_tags.indexOf(new_ID);
+            if (index > 0) {
+                // Remove tag from authorized list
+                authorized_tags =
+                    authorized_tags.substring(0, index - 1) +
+                    authorized_tags.substring(index + new_ID.length());
+                beep(200, 2);
+            } else {
+                // Add tag to authorized list
+                authorized_tags = authorized_tags + " " + new_ID;
+                beep(200, 1);
+            }
+        } else {
+            int index = authorized_tags.indexOf(new_ID);
 
-      // Check if tag is authorized
-      if (index > 0) 
-      {
-        //Access permitted :)
-        beep(600, 1);
-      }
-      else
-      {
-        // Access denied!
-        beep(600, 2);
-      }  
+            // Check if tag is authorized
+            if (index > 0) {
+                // Access permitted :)
+                beep(600, 1);
+            } else {
+                // Access denied!
+                beep(600, 2);
+            }
+        }
     }
-  }
 }
 
 // Plays a beep sound
-void beep(int duration, int times)
-{
-  for(int i = 0; i < times; ++i)
-  {
-    digitalWrite(buzzer_pin, HIGH);
-    delay(duration/2);
-    digitalWrite(buzzer_pin, LOW);
-    delay(duration/2);
-  }
+void beep(int duration, int times) {
+    for (int i = 0; i < times; ++i) {
+        digitalWrite(buzzer_pin, HIGH);
+        delay(duration / 2);
+        digitalWrite(buzzer_pin, LOW);
+        delay(duration / 2);
+    }
 }

--- a/examples/SimpleRead/SimpleRead.ino
+++ b/examples/SimpleRead/SimpleRead.ino
@@ -1,9 +1,9 @@
 /*
-  Prints out the ID of any chip you scan.
-  
-  Created on 4 Apr 2019 by
-  Luai Malek and
-  Roman Schulte
+    Prints out the ID of any chip you scan.
+
+    Created on 4 Apr 2019 by
+    Luai Malek and
+    Roman Schulte
 */
 
 #include "SimpleRFID.h"
@@ -15,17 +15,19 @@ const uint8_t rfid_rx_pin = 2;
 const uint8_t rfid_tx_pin = 3;
 SimpleRFID simple_rfid(rfid_rx_pin, rfid_tx_pin);
 
-void setup() 
-{
-  Serial.begin(9600); 
+void setup() {
+    Serial.begin(9600);
+    Serial.println("SimpleRead.ino");
 }
 
 void loop() {
-  if (simple_rfid.available()) //check if data is ready to be read
-  {
-    ID = simple_rfid.readID(); //read the ID
-    Serial.println(ID); //print the String 
-  }
+    // check if data is ready to be read
+    if (simple_rfid.available()) {
+        // read the ID
+        ID = simple_rfid.readID();
+        // print the String
+        Serial.println(ID);
+    }
 
-  //Here you can add additional behaviour if wanted.
+    // Here you can add additional behaviour if wanted.
 }

--- a/src/SimpleRFID.cpp
+++ b/src/SimpleRFID.cpp
@@ -3,43 +3,39 @@
     Released into the public domain.
 */
 
+#include "SimpleRFID.h"
 #include "Arduino.h"
 #include <SoftwareSerial.h>
-#include "SimpleRFID.h"
 
-SimpleRFID::SimpleRFID(uint8_t rx_pin, uint8_t tx_pin)
-{
+SimpleRFID::SimpleRFID(uint8_t rx_pin, uint8_t tx_pin) {
     _simpleRFID_SoftSerial = new SoftwareSerial(rx_pin, tx_pin);
-    _simpleRFID_SoftSerial->begin(9600); //The RFID readers baudrate is fixed at 9600
+    // The RFID readers baudrate is fixed at 9600
+    _simpleRFID_SoftSerial->begin(9600);
 }
 
-SimpleRFID::~SimpleRFID()
-{
-    delete _simpleRFID_SoftSerial;
-}
+SimpleRFID::~SimpleRFID() { delete _simpleRFID_SoftSerial; }
 
-bool SimpleRFID::available()
-{
-    return _simpleRFID_SoftSerial->available() > 0;
-}
+bool SimpleRFID::available() { return _simpleRFID_SoftSerial->available() > 0; }
 
-String SimpleRFID::readID()
-{
+String SimpleRFID::readID() {
     String result = "";
     unsigned char temp_char;
     int check_int;
-    do{
-        temp_char = (unsigned char) _simpleRFID_SoftSerial->read();
-        check_int = (int) temp_char;    //used to check, if temp_char is valid data
-        //Control-characters are rendered invalid data. Consult ASCII-table for further information.
-        if(check_int != 2 && check_int != 3 && check_int != 255)
-        {
-            result += (char) temp_char; //append valid character to output-string
+    do {
+        temp_char = (unsigned char)_simpleRFID_SoftSerial->read();
+        // used to check, if temp_char is valid data
+        check_int = (int)temp_char;
+        // Control-characters are rendered invalid data.
+        // Consult ASCII-table for further information.
+        if (check_int != 2 && check_int != 3 && check_int != 255) {
+            // append valid character to output-string
+            result += (char)temp_char;
         }
-    }while(check_int != 3); //the control-character "end of message" ends the reading process
-    while(_simpleRFID_SoftSerial->available())
-    {
-        char junk = _simpleRFID_SoftSerial->read();    //clear input buffer in case the reader read twice
+    } while (check_int != 3);
+    // the control-character "end of message" ends the reading process
+    while (_simpleRFID_SoftSerial->available()) {
+        // clear input buffer in case the reader read twice
+        char junk = _simpleRFID_SoftSerial->read();
     }
     return result;
 }

--- a/src/SimpleRFID.h
+++ b/src/SimpleRFID.h
@@ -1,6 +1,6 @@
 /*
-    SIMPLE_RFID.h - Library intended for easy use of the "Grove-125KHz RFID Reader v1.0".
-    Created by Roman Schulte and Luai Malek, April 4, 2019.
+    SIMPLE_RFID.h - Library intended for easy use of the "Grove-125KHz RFID
+   Reader v1.0". Created by Roman Schulte and Luai Malek, April 4, 2019.
     Released into the public domain.
 */
 
@@ -11,26 +11,25 @@
 #include "SoftwareSerial.h"
 
 /*
-    Abstraction handling the serial interface and data-type conversions internally.
-    Users only need to use the provided high-level functions.
+    Abstraction handling the serial interface and data-type conversions
+   internally. Users only need to use the provided high-level functions.
 */
-class SimpleRFID
-{
-    public:
-    //Constructor
+class SimpleRFID {
+public:
+    // Constructor
     SimpleRFID(uint8_t rx_pin, uint8_t tx_pin);
 
-    //Returns whether the reader is holding data, ready to be read
+    // Returns whether the reader is holding data, ready to be read
     bool available();
 
-    //Returns the ID of the currently read RFID-chip 
+    // Returns the ID of the currently read RFID-chip
     String readID();
 
-    //Destructor
+    // Destructor
     ~SimpleRFID();
 
-    private:
-    SoftwareSerial* _simpleRFID_SoftSerial;
+private:
+    SoftwareSerial *_simpleRFID_SoftSerial;
 };
 
 #endif

--- a/src/SimpleRFID2.cpp
+++ b/src/SimpleRFID2.cpp
@@ -1,0 +1,261 @@
+/*
+    SimpleRFID2
+
+    based on 
+    - SimpleRFID by Roman Schulte and Luai Malek, April 4, 2019
+
+*/
+
+#include "SimpleRFID2.h"
+#include "Arduino.h"
+#include <SoftwareSerial.h>
+
+SimpleRFID2::SimpleRFID2(uint8_t rx_pin, uint8_t tx_pin) {
+    _simpleRFID_SoftSerial = new SoftwareSerial(rx_pin, tx_pin);
+    // The RFID readers baudrate is fixed at 9600
+    _simpleRFID_SoftSerial->begin(9600);
+    // activate
+    _simpleRFID_SoftSerial->listen();
+}
+
+SimpleRFID2::~SimpleRFID2() { delete _simpleRFID_SoftSerial; }
+
+bool SimpleRFID2::available() {
+    return _simpleRFID_SoftSerial->available() > 0;
+}
+
+// uint32_t SimpleRFID2::readDecodedID() {
+//     String result = "";
+//     unsigned char temp_char;
+//     int check_int;
+//     do {
+//         temp_char = (unsigned char)_simpleRFID_SoftSerial->read();
+//         // used to check, if temp_char is valid data
+//         check_int = (int)temp_char;
+//         // Control-characters are rendered invalid data.
+//         // Consult ASCII-table for further information.
+//         if (check_int != 2 && check_int != 3 && check_int != 255) {
+//             // append valid character to output-string
+//             result += (char)temp_char;
+//         }
+//     } while (check_int != 3);
+//     // the control-character "end of message" ends the reading process
+//     while (_simpleRFID_SoftSerial->available()) {
+//         // clear input buffer in case the reader read twice
+//         char junk = _simpleRFID_SoftSerial->read();
+//     }
+//     return result;
+// }
+
+// uint32_t SimpleRFID2::readDecodedID(bool detailed_output = false) {
+uint32_t SimpleRFID2::readDecodedID() {
+    // returns tag id if tag is read. 0 otherwise.
+    bool detailed_output = false;
+    int32_t tag = 0;
+    while (_simpleRFID_SoftSerial->available() > 0) {
+        bool call_extract_tag = false;
+
+        int inputChar = _simpleRFID_SoftSerial->read(); // read
+        // Serial.print("inputChar : ");
+        // Serial.print(inputChar, DEC);
+        // Serial.print(" - 0x");
+        // Serial.print(inputChar, HEX);
+        // Serial.print(" - ");
+        // Serial.print(char(inputChar));
+        // Serial.println("");
+        if (inputChar == -1) {
+            // no data was read
+            // should not happen - as we first check for available...
+        } else {
+            // RDM630/RDM6300 found a tag => tag incoming
+            if (inputChar == MSG_HEAD) {
+                buffer_index = 0;
+            } else if (inputChar == MSG_TAIL) {
+                // tag has been fully transmitted
+                // extract tag at the end of the function call
+                call_extract_tag = true;
+            } else {
+                // checking for a buffer overflow (It's very unlikely that
+                // an buffer overflow comes up!)
+                if (buffer_index >= BUFFER_SIZE) {
+                    // Serial.println("Error: Buffer overflow detected! ");
+                } else {
+                    // everything is alright => copy current value to buffer
+                    buffer.raw[buffer_index++] = inputChar;
+                }
+            }
+
+            if (call_extract_tag == true) {
+                if (buffer_index == PAYLOAD_SIZE) {
+                    tag = extract_tag(detailed_output);
+                } else {
+                    // something is wrong...
+                    // start again looking for MSG_HEAD
+                    buffer_index = 0;
+                    return;
+                }
+            }
+        }
+    }
+    return tag;
+}
+
+uint32_t SimpleRFID2::extract_tag(bool detailed_output = false) {
+    uint32_t tagDecimal = hexStrToDecimal(buffer.data.tag, DATA_TAG_SIZE);
+    uint32_t checksumDecimal = hexStrToDecimal(buffer.checksum, CHECKSUM_SIZE);
+
+    // Serial.println("calculate decimal checksum: ");
+    uint32_t checksumDecimalCalculated = 0;
+    for (int i = 0; i < DATA_SIZE; i += 2) {
+        // why ever - this does not work..
+        // uint32_t val = hexStrToDecimal(buffer.data.raw[i], 2);
+        // this AI generated code snippet works as expected.
+        // should be the same...
+        char byteStr[3];
+        byteStr[0] = buffer.data.raw[i];
+        byteStr[1] = buffer.data.raw[i + 1];
+        byteStr[2] = '\0'; // null-terminate the string
+        uint8_t byteValue = (uint8_t)strtol(byteStr, NULL, 16);
+
+        // Serial.print("  ");
+        // Serial.print(i);
+        // Serial.print(" ");
+        // Serial.print("'");
+        // Serial.print(char(buffer.data.raw[i]));
+        // Serial.print("'");
+        // Serial.print(" → ");
+        // Serial.print(val);
+        // Serial.print(" → ");
+        // Serial.print(byteValue);
+        // Serial.println();
+        checksumDecimalCalculated ^= byteValue;
+    }
+
+    // print message that was sent from RDM630/RDM6300
+    if (detailed_output) {
+        Serial.println("------------------------------------------");
+
+        Serial.println("Buffer content:");
+        Serial.print("HEX  : ");
+        for (int i = 0; i < BUFFER_SIZE; ++i) {
+            Serial.print(buffer.raw[i]);
+            Serial.print(" ");
+        }
+        Serial.println(";");
+        Serial.print("char  : ");
+        for (int i = 0; i < BUFFER_SIZE; ++i) {
+            Serial.print(char(buffer.raw[i]));
+            Serial.print(" ");
+        }
+        Serial.println(";");
+
+        Serial.println("------------------------------------------");
+
+        Serial.println("DATA content:");
+
+        Serial.print("ASCII: ");
+        for (int i = DATA_VERSION_SIZE; i < DATA_SIZE; ++i) {
+            Serial.print(char(buffer.raw[i]));
+            Serial.print(" ");
+        }
+        Serial.println("; char()");
+
+        Serial.print("ASCII: ");
+        for (int i = 0; i < DATA_SIZE; ++i) {
+            Serial.print(char(buffer.data.raw[i]));
+            Serial.print(".");
+        }
+        Serial.println("; char()");
+
+        Serial.println("------------------------------------------");
+        // Serial.print("hexCStrToString: ");
+        // Serial.print(hexCStrToString(buffer));
+
+        Serial.println("Message (HEX): ");
+
+        // Serial.print("  head    : ");
+        // Serial.print(char(buffer.head));
+        // Serial.println("");
+
+        Serial.print("  version : ");
+        for (int i = 0; i < DATA_VERSION_SIZE; ++i) {
+            Serial.print(char(buffer.data.version[i]));
+            Serial.print(" ");
+        }
+        Serial.println("");
+
+        Serial.print("  tag     : ");
+        for (int i = 0; i < DATA_TAG_SIZE; ++i) {
+            Serial.print(char(buffer.data.tag[i]));
+            Serial.print(" ");
+        }
+        Serial.println("");
+
+        Serial.print("  checksum: ");
+        for (int i = 0; i < CHECKSUM_SIZE; ++i) {
+            Serial.print(char(buffer.checksum[i]));
+        }
+        Serial.println("");
+
+        // Serial.print("  tail    : ");
+        // Serial.print(char(buffer.tail));
+        // Serial.println("");
+
+        Serial.println("------------------------------------------");
+
+        Serial.print("Extracted Tag: ");
+        Serial.println(tagDecimal);
+
+        Serial.println(tagDecimalToString(tagDecimal));
+
+        Serial.println("checksum: ");
+        Serial.print("  ");
+        // compare calculated checksum to retrieved checksum
+        if (checksumDecimalCalculated == checksumDecimal) {
+            // checksum matches.
+            Serial.print("OK");
+        } else {
+            // checksums mismatch
+            Serial.print("mismatch");
+            Serial.println();
+            Serial.print("  checksumDecimal: ");
+            Serial.println(checksumDecimal);
+            Serial.print("  checksumDecimalCalculated: ");
+            Serial.println(checksumDecimalCalculated);
+        }
+        Serial.println();
+
+        Serial.println("------------------------------------------");
+    }
+
+    if (checksumDecimalCalculated != checksumDecimal) {
+        // checksum mismatch
+        // so we return 0.
+        tagDecimal = 0;
+    }
+    return tagDecimal;
+}
+
+// converts a hexadecimal value (encoded as ASCII string) to a numeric value
+uint32_t SimpleRFID2::hexStrToDecimal(char *str, unsigned int length) {
+
+    char *copy = malloc((sizeof(char) * length) + 1);
+    // the variable "copy" is a copy of the parameter "str".
+    memcpy(copy, str, sizeof(char) * length);
+    // "copy" has an additional '\0' element to make sure that "str" is
+    // null-terminated.
+    copy[length] = '\0';
+    // strtol converts a null-terminated string to a long value
+    uint32_t value = strtol(copy, NULL, 16);
+    // clean up
+    free(copy);
+    return value;
+}
+
+String SimpleRFID2::tagDecimalToString(uint32_t decimal, uint8_t fillWidth) {
+    String decimalStr = String(decimal);
+    while (decimalStr.length() < fillWidth) {
+        decimalStr = "0" + decimalStr;
+    }
+    return decimalStr;
+}

--- a/src/SimpleRFID2.h
+++ b/src/SimpleRFID2.h
@@ -1,0 +1,113 @@
+/*
+    SimpleRFID2
+    Library intended for easy use of the "Grove-125KHz RFID Reader v1.0"
+    all RDM6300 readers should work.
+
+    based on
+    - SimpleRFID
+        by Roman Schulte and Luai Malek, April 4, 2019.
+        (public domain/ MIT)
+    - www.mschoeffler.de Arduino Examples
+        https://mschoeffler.com/2018/01/05/arduino-tutorial-how-to-use-the-rdm630-rdm6300-rfid-reader/
+    - Amir Mohammad Shojaee @ Electropeak
+        modified on 20 Jan 2020
+        https://electropeak.com/learn/interfacing-rdm6300-125khz-rfid-reader-module-with-arduino/
+    - RFID.h
+        20220531 s-light.eu stefan krüger
+        extracted RFID code into extra file and some light tweaks.
+        https://github.com/s-light/MYS__52-RFID-Leser/blob/master/examples/RFID_125kHz_RDM6300__withIdDecoding/RFID_125kHz_RDM6300__withIdDecoding.ino
+
+    converted to SimpleRFID2 Library
+        by s-light.eu stefan krüger
+        24.05.2025
+
+
+*/
+
+#ifndef SIMPLE_RFID2_H
+#define SIMPLE_RFID2_H
+
+#include "Arduino.h"
+#include "SoftwareSerial.h"
+
+// slightly advanced handling.
+class SimpleRFID2 {
+public:
+    // Constructor
+    SimpleRFID2(uint8_t rx_pin, uint8_t tx_pin);
+
+    // Returns whether the reader is holding data, ready to be read
+    bool available();
+
+    // returns the ID as string with leading '0'
+    // String readID();
+
+    // returns the last read ID as unsigned long integer (if reading / checksum
+    // failed it returns 0)
+    uint32_t readDecodedID();
+
+    // convert decimal to String and fill with leading '0'
+    static String tagDecimalToString(uint32_t decimal, uint8_t fillWidth=10);
+
+    // Destructor
+    ~SimpleRFID2();
+
+private:
+    SoftwareSerial *_simpleRFID_SoftSerial;
+
+    // decoding info
+    // https://forum.arduino.cc/t/rdm6300-reading-format/1072597/10
+    // https://elty.pl/upload/download/RFID/RDM630-Spec.pdf
+    // RFID DATA FRAME FORMAT:
+    //      1byte head (value: 2),
+    //      10byte data (2byte version + 8byte tag),
+    //      2byte checksum,
+    //      1byte tail (value: 3)
+    static const int BUFFER_SIZE = 14;
+    // 2byte version (actual meaning of these two bytes may vary)
+    static const int DATA_VERSION_SIZE = 2;
+    // 8byte tag
+    static const int DATA_TAG_SIZE = 8;
+    // 10byte data (2byte version + 8byte tag)
+    static const int DATA_SIZE = DATA_VERSION_SIZE + DATA_TAG_SIZE;
+    // 2byte checksum
+    static const int CHECKSUM_SIZE = 2;
+    static const int PAYLOAD_SIZE = DATA_SIZE + CHECKSUM_SIZE;
+
+    static const int MSG_HEAD = 0x02;
+    static const int MSG_TAIL = 0x03;
+
+    // unions
+    // https://legacy.cplusplus.com/doc/tutorial/other_data_types/
+    // to hold the incoming message.
+    // this way it is easy to access the different parts.
+    union data_t {
+        char raw[DATA_SIZE];
+        struct {
+            char version[DATA_VERSION_SIZE];
+            char tag[DATA_TAG_SIZE];
+        };
+    };
+    union message_t {
+        char raw[PAYLOAD_SIZE];
+        struct {
+            // char head;
+            data_t data;
+            char checksum[CHECKSUM_SIZE];
+            // char tail;
+        };
+    };
+
+    // used to store an incoming data frame
+    message_t buffer;
+    int buffer_index = 0;
+
+    uint32_t extract_tag(bool detailed_output = false);
+
+    // converts a hexadecimal value (encoded as ASCII string) to a numeric
+    // value
+    static uint32_t hexStrToDecimal(char *str, unsigned int length);
+
+};
+
+#endif


### PR DESCRIPTION
this pull-request adds a SimpleRFID2 class that has an very similar interface - 
and adds the data decoding with checksum verification.
this way the returned tag-id  (as uint32_t) is the same as printed on the  physical cards / chips..

currently as extra class - in separat files.
i think it would make sens to just leave one implementation - 
but did first want to have your thought on that...